### PR TITLE
タイトル下に技術スタックのバッジを中央揃えで追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
-
 <div align="center">
   <img src="docs/header.svg" width="800">
   <h1>🐱 Neko Neko Space Travel 🚀</h1>
   <h3>～ 宇宙への冒険をご一緒に ～</h3>
+
+  <p align="center">
+    <img src="https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54" alt="Python">
+    <img src="https://img.shields.io/badge/OpenAI-412991?style=for-the-badge&logo=openai&logoColor=white" alt="OpenAI">
+    <img src="https://img.shields.io/badge/phidata-FF6B6B?style=for-the-badge&logo=python&logoColor=white" alt="Phidata">
+    <img src="https://img.shields.io/badge/streamlit-FF4B4B?style=for-the-badge&logo=streamlit&logoColor=white" alt="Streamlit">
+    <img src="https://img.shields.io/badge/postgresql-4169E1?style=for-the-badge&logo=postgresql&logoColor=white" alt="PostgreSQL">
+    <img src="https://img.shields.io/badge/stripe-008CDD?style=for-the-badge&logo=stripe&logoColor=white" alt="Stripe">
+    <img src="https://img.shields.io/badge/prometheus-E6522C?style=for-the-badge&logo=prometheus&logoColor=white" alt="Prometheus">
+    <img src="https://img.shields.io/badge/grafana-F46800?style=for-the-badge&logo=grafana&logoColor=white" alt="Grafana">
+  </p>
 </div>
 
 ## 📘 概要
@@ -19,15 +29,6 @@
 - 😺 フレンドリーなねこスタッフ
 
 ## 🔧 技術スタック
-
-![Python](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54)
-![OpenAI](https://img.shields.io/badge/OpenAI-412991?style=for-the-badge&logo=openai&logoColor=white)
-![Phidata](https://img.shields.io/badge/phidata-FF6B6B?style=for-the-badge&logo=python&logoColor=white)
-![Streamlit](https://img.shields.io/badge/streamlit-FF4B4B?style=for-the-badge&logo=streamlit&logoColor=white)
-![PostgreSQL](https://img.shields.io/badge/postgresql-4169E1?style=for-the-badge&logo=postgresql&logoColor=white)
-![Stripe](https://img.shields.io/badge/stripe-008CDD?style=for-the-badge&logo=stripe&logoColor=white)
-![Prometheus](https://img.shields.io/badge/prometheus-E6522C?style=for-the-badge&logo=prometheus&logoColor=white)
-![Grafana](https://img.shields.io/badge/grafana-F46800?style=for-the-badge&logo=grafana&logoColor=white)
 
 - **バックエンド**: Python, phidata, OpenAI
 - **フロントエンド**: Streamlit

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <div align="center">
   <img src="docs/header.svg" width="800">
   <h1>🐱 Neko Neko Space Travel 🚀</h1>
@@ -18,6 +19,15 @@
 - 😺 フレンドリーなねこスタッフ
 
 ## 🔧 技術スタック
+
+![Python](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54)
+![OpenAI](https://img.shields.io/badge/OpenAI-412991?style=for-the-badge&logo=openai&logoColor=white)
+![Phidata](https://img.shields.io/badge/phidata-FF6B6B?style=for-the-badge&logo=python&logoColor=white)
+![Streamlit](https://img.shields.io/badge/streamlit-FF4B4B?style=for-the-badge&logo=streamlit&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/postgresql-4169E1?style=for-the-badge&logo=postgresql&logoColor=white)
+![Stripe](https://img.shields.io/badge/stripe-008CDD?style=for-the-badge&logo=stripe&logoColor=white)
+![Prometheus](https://img.shields.io/badge/prometheus-E6522C?style=for-the-badge&logo=prometheus&logoColor=white)
+![Grafana](https://img.shields.io/badge/grafana-F46800?style=for-the-badge&logo=grafana&logoColor=white)
 
 - **バックエンド**: Python, phidata, OpenAI
 - **フロントエンド**: Streamlit


### PR DESCRIPTION
## 変更内容
- READMEのタイトルセクション直下に技術スタックのバッジを追加
- バッジを中央揃えで配置
- 各技術のバージョンや公式サイトへのリンクを含むバッジを追加

## バッジの追加技術
- Python
- OpenAI
- phidata
- Streamlit
- PostgreSQL
- Stripe
- Prometheus
- Grafana

## スクリーンショット
バッジは以下のように表示されます：
- Python: 青系の配色で公式ロゴ付き
- OpenAI: 紫系の配色で公式ロゴ付き
- その他の技術: それぞれの公式カラーとロゴを使用

Closes #1